### PR TITLE
Dependency management

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -9,6 +9,9 @@ updates:
     commit-message:
       prefix: chore
       include: scope
+    groups:
+      all-actions:
+        patterns: ['*']
   - package-ecosystem: github-actions
     directory: /
     schedule:
@@ -17,3 +20,6 @@ updates:
     commit-message:
       prefix: chore
       include: scope
+    groups:
+      all-actions:
+        patterns: ['*']

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -5,11 +5,15 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: chore
+      include: scope
   - package-ecosystem: github-actions
-    directory: "/"
+    directory: /
     schedule:
       interval: weekly
     open-pull-requests-limit: 10
     commit-message:
-      prefix: "chore"
-      include: "scope"
+      prefix: chore
+      include: scope

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -4,8 +4,6 @@ on:
   push:
     branches: [master]
   pull_request:
-  schedule:
-    - cron: 0 5 * * 0  # every sunday 05:00 UTC
 
 jobs:
   integration-test:

--- a/.github/workflows/updated-deps.yaml
+++ b/.github/workflows/updated-deps.yaml
@@ -1,0 +1,28 @@
+name: Check for outdated dependencies
+
+on:
+  pull_request:
+  schedule:
+    - cron: 0 5 * * 0  # every sunday 05:00 UTC
+
+jobs:
+  check-dependencies:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - name: Install dependencies
+        run: npm clean-install
+      - name: Check for outdated dependencies
+        run: |-
+          OUTDATED=$(npm outdated || true)
+          if [ -n "$OUTDATED" ]; then
+            echo "Outdated dependencies found:"
+            echo "$OUTDATED"
+            exit 1
+          fi

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Get Supported GHC Version
 
 [![Test Get Supported GHC Version Action](https://github.com/webdevred/get-supported-ghc/actions/workflows/test.yaml/badge.svg)](https://github.com/webdevred/get-supported-ghc/actions/workflows/test.yaml)
+[![Check for outdated dependencies](https://github.com/webdevred/get-supported-ghc/actions/workflows/updated-deps.yaml/badge.svg?event=schedule)](https://github.com/webdevred/get-supported-ghc/actions/workflows/updated-deps.yaml)
 
 This GitHub Action automatically detects the latest GHC (Glasgow Haskell Compiler) version compatible with your Haskell project's `base` dependency constraint in `package.yaml`.
 


### PR DESCRIPTION
This PR includes three separate improvements related to dependency management and CI:

**Dependabot configuration**
- Increased open-pull-requests-limit to 10 for both npm and GitHub Actions.
- Standardized commit messages: prefix: chore, include: scope.
- Minor formatting adjustments in .github/dependabot.yaml.

**CI – test workflow**
- Removed weekly schedule from test.yaml.
- Integration tests now run only on push to master and on pull requests.

**New workflow to detect outdated npm dependencies**
- Added updated-deps.yaml, running every Sunday.
- Installs dependencies and runs npm outdated.
- Fails the workflow if any dependencies are outdated, providing automatic notification of required updates.