### PR TITLE
feat: validate base lower bound and add min/max GHC version outputs

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -29,9 +29,21 @@ jobs:
         with:
           package-yaml-path: examples/package-equal-or-less-than.yaml
         id: ghc-version-inclusive
-      - name: Assert output
+      - name: Assert max-ghc-version output
         run: |-
-          if [ "${{ steps.ghc-version-inclusive.outputs.ghc-version }}" != "9.0.1" ]; then
+          if [ "${{ steps.ghc-version-inclusive.outputs.max-ghc-version }}" != "9.0.1" ]; then
+            exit 1
+          fi
+        shell: bash
+      - name: Assert deprecated ghc-version output matches max-ghc-version
+        run: |-
+          if [ "${{ steps.ghc-version-inclusive.outputs.ghc-version }}" != "${{ steps.ghc-version-inclusive.outputs.max-ghc-version }}" ]; then
+            exit 1
+          fi
+        shell: bash
+      - name: Assert min-ghc-version output is set
+        run: |-
+          if [ -z "${{ steps.ghc-version-inclusive.outputs.min-ghc-version }}" ]; then
             exit 1
           fi
         shell: bash
@@ -40,9 +52,27 @@ jobs:
         with:
           package-yaml-path: examples/package-less-than.yaml
         id: ghc-version-exclusive
-      - name: Assert output
+      - name: Assert max-ghc-version output
         run: |-
-          if [ "${{ steps.ghc-version-exclusive.outputs.ghc-version }}" != "8.10.7" ]; then
+          if [ "${{ steps.ghc-version-exclusive.outputs.max-ghc-version }}" != "8.10.7" ]; then
+            exit 1
+          fi
+        shell: bash
+      - name: Run action with validate-lower-bound
+        uses: ./
+        with:
+          package-yaml-path: examples/package-validate-lower-bound.yaml
+          validate-lower-bound: 'true'
+        id: ghc-version-validated
+      - name: Assert validate-lower-bound passes and max-ghc-version is set
+        run: |-
+          if [ -z "${{ steps.ghc-version-validated.outputs.max-ghc-version }}" ]; then
+            exit 1
+          fi
+        shell: bash
+      - name: Assert min-ghc-version is 9.0.1 for base >= 4.15
+        run: |-
+          if [ "${{ steps.ghc-version-validated.outputs.min-ghc-version }}" != "9.0.1" ]; then
             exit 1
           fi
         shell: bash

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Get Supported GHC Version
 
 [![Test Get Supported GHC Version Action](https://github.com/webdevred/get-supported-ghc/actions/workflows/test.yaml/badge.svg)](https://github.com/webdevred/get-supported-ghc/actions/workflows/test.yaml)
-[![Check for outdated dependencies](https://github.com/webdevred/get-supported-ghc/actions/workflows/updated-deps.yaml/badge.svg?event=schedule)](https://github.com/webdevred/get-supported-ghc/actions/workflows/updated-deps.yaml)
 
 <!--toc:start-->
 - [Get Supported GHC Version](#get-supported-ghc-version)
@@ -16,15 +15,18 @@ Useful for CI/CD workflows where you want to install a GHC version that satisfie
 
 ## Inputs
 
-| Input               | Description                                                | Default        | Required |
-|---------------------|------------------------------------------------------------|----------------|----------|
-| `package-yaml-path` | Path to your `package.yaml` file relative to the repo root | `package.yaml` | No       |
+| Input                  | Description                                                                                                                                 | Default        | Required |
+|------------------------|---------------------------------------------------------------------------------------------------------------------------------------------|----------------|----------|
+| `package-yaml-path`    | Path to your `package.yaml` file relative to the repo root                                                                                  | `package.yaml` | No       |
+| `validate-lower-bound` | Fail if the base lower bound covers GHC major versions with breaking changes below the minimum version in `tested-with` in your package.yaml | `false`        | No       |
 
 ## Outputs
 
-| Output        | Description                                  |
-|---------------|----------------------------------------------|
-| `ghc-version` | The latest compatible GHC version to install |
+| Output            | Description                                                 |
+|-------------------|-------------------------------------------------------------|
+| `max-ghc-version` | The latest compatible GHC version to install                |
+| `min-ghc-version` | The oldest GHC version whose base satisfies the lower bound |
+| `ghc-version`     | Deprecated - use `max-ghc-version` instead                  |
 
 ## Example Usage
 
@@ -40,14 +42,24 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-      - name: Get latest supported GHC version
+      - name: Get supported GHC versions
         id: get-ghc
         uses: webdevred/get-supported-ghc@v0.0.1
         with:
           package-yaml-path: examples/package.yaml
-      - name: Set up GHC latest and Cabal
-        id: setup-ghc
+          validate-lower-bound: true
+      - name: Set up GHC and Cabal
         uses: haskell-actions/setup@v2.8.0
         with:
-          ghc-version: "${{ steps.get-ghc.outputs.ghc-version }}"
+          ghc-version: "${{ steps.get-ghc.outputs.max-ghc-version }}"
 ```
+
+For `validate-lower-bound` to work, add a `tested-with` field to your `package.yaml`:
+
+```yaml
+tested-with: GHC == 9.6.4, GHC == 9.8.2, GHC == 9.10.1
+dependencies:
+  - base >= 4.18 && < 4.22
+```
+
+If the `base` lower bound covers GHC major versions below your tested minimum (e.g. lower bound allows GHC 8.x but you only test with GHC 9.x), the action fails with a descriptive error.

--- a/action.yml
+++ b/action.yml
@@ -17,5 +17,9 @@ inputs:
     default: 'false'
 
 outputs:
-  ghc-version:
+  max-ghc-version:
     description: The GHC version to install
+  ghc-version:
+    description: 'Deprecated - use max-ghc-version instead'
+  min-ghc-version:
+    description: The oldest GHC version whose base satisfies the lower bound in package.yaml

--- a/action.yml
+++ b/action.yml
@@ -11,6 +11,10 @@ inputs:
     description: 'Path to package.yaml (default: package.yaml in repo root)'
     required: false
     default: package.yaml
+  validate-lower-bound:
+    description: 'Fail if the base lower bound covers GHC major versions with breaking changes below the minimum version in tested-with'
+    required: false
+    default: 'false'
 
 outputs:
   ghc-version:

--- a/examples/package-validate-lower-bound.yaml
+++ b/examples/package-validate-lower-bound.yaml
@@ -1,0 +1,14 @@
+name: my-haskell-package
+version: 0.1.0.0
+
+tested-with: GHC == 9.0.1, GHC == 9.2.8
+
+dependencies:
+  - base >= 4.15 && <= 4.17
+  - containers
+  - text
+
+library:
+  exposed-modules: MyLib
+  source-dirs: src
+  ghc-options: -Wall

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,22 +41,21 @@ async function runCommand(cmd: string): Promise < string > {
   return stdout.trim();
 }
 
-function getUpperBound(constraint: string): BaseBound | null {
-  const match = constraint.match(/(<=|<)\s*((\d+)(\.(\d+))?(\.(\d+))?)/);
+function parseBound(constraint: string, regex: RegExp, inclusiveOp: string): BaseBound | null {
+  const match = constraint.match(regex);
   if (!match) return null;
   return {
-    inclusive: match[1] === "<=",
+    inclusive: match[1] === inclusiveOp,
     version: match[2]
   };
 }
 
+function getUpperBound(constraint: string): BaseBound | null {
+  return parseBound(constraint, /(<=|<)\s*((\d+)(\.(\d+))?(\.(\d+))?)/, "<=");
+}
+
 function getLowerBound(constraint: string): BaseBound | null {
-  const match = constraint.match(/(>=|>)\s*((\d+)(\.(\d+))?(\.(\d+))?)/);
-  if (!match) return null;
-  return {
-    inclusive: match[1] === ">=",
-    version: match[2]
-  };
+  return parseBound(constraint, /(>=|>)\s*((\d+)(\.(\d+))?(\.(\d+))?)/, ">=");
 }
 
 function normalizeVersion(version: string, segments = 3): number[] {
@@ -76,18 +75,25 @@ function compareVersions(a: string, b: string): number {
   return 0;
 }
 
-function satisfiesUpperBound(baseVersion: string, bound: BaseBound): boolean {
+function satisfiesBound(baseVersion: string, bound: BaseBound, direction: 1 | -1): boolean {
   const cmp = compareVersions(baseVersion, bound.version);
-  return cmp < 0 || (cmp === 0 && bound.inclusive);
+  return cmp === direction || (cmp === 0 && bound.inclusive);
+}
+
+function satisfiesUpperBound(baseVersion: string, bound: BaseBound): boolean {
+  return satisfiesBound(baseVersion, bound, -1);
 }
 
 function satisfiesLowerBound(baseVersion: string, bound: BaseBound): boolean {
-  const cmp = compareVersions(baseVersion, bound.version);
-  return cmp > 0 || (cmp === 0 && bound.inclusive);
+  return satisfiesBound(baseVersion, bound, 1);
 }
 
 function ghcMajorVersion(version: string): number {
   return Number(version.split(".")[0]);
+}
+
+function boundOp(bound: BaseBound, type: "<" | ">"): string {
+  return bound.inclusive ? `${type}=` : type;
 }
 
 interface ParsedPackageYaml {
@@ -177,6 +183,7 @@ async function main(): Promise < void > {
         ghcMajorVersion(entry.version) < minTestedMajor
       );
       if (breakingVersions.length > 0) {
+        breakingVersions.sort((a, b) => compareVersions(b.version, a.version));
         const oldest = breakingVersions[breakingVersions.length - 1].version;
         const newest = breakingVersions[0].version;
         throw new Error(
@@ -191,7 +198,7 @@ async function main(): Promise < void > {
 
     if (validVersions.length === 0) {
       throw new Error(
-        `No GHC version found with base <${baseUpperBound.inclusive ? "=" : ""} ${baseUpperBound.version}`
+        `No GHC version found with base ${boundOp(baseUpperBound, "<")} ${baseUpperBound.version}`
       );
     }
 
@@ -200,7 +207,7 @@ async function main(): Promise < void > {
     const latestGhc = validVersions[0].version;
 
     githubCore.info(
-      `Latest GHC under base <${baseUpperBound.inclusive ? "=" : ""} ${baseUpperBound.version}: ${latestGhc}`
+      `Latest GHC under base ${boundOp(baseUpperBound, "<")} ${baseUpperBound.version}: ${latestGhc}`
     );
 
     githubCore.setOutput("max-ghc-version", latestGhc);
@@ -214,7 +221,7 @@ async function main(): Promise < void > {
         lowerCandidates.sort((a, b) => compareVersions(a.version, b.version));
         const minGhc = lowerCandidates[0].version;
         githubCore.info(
-          `Oldest GHC under base >${baseLowerBound.inclusive ? "=" : ""} ${baseLowerBound.version}: ${minGhc}`
+          `Oldest GHC under base ${boundOp(baseLowerBound, ">")} ${baseLowerBound.version}: ${minGhc}`
         );
         githubCore.setOutput("min-ghc-version", minGhc);
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,9 +11,14 @@ import * as githubCore from "@actions/core";
 
 const execAsync = promisify(exec);
 
-interface BaseUpperBound {
+interface BaseBound {
   inclusive: boolean;
   version: string;
+}
+
+interface BaseBounds {
+  lower: BaseBound | null;
+  upper: BaseBound;
 }
 
 interface PackageYaml {
@@ -21,6 +26,7 @@ interface PackageYaml {
     name: string;
     version: string;
   } > ;
+  "tested-with" ? : string;
 }
 
 interface GhcEntry {
@@ -35,17 +41,21 @@ async function runCommand(cmd: string): Promise < string > {
   return stdout.trim();
 }
 
-function getBaseUpperBound(baseBound: string): BaseUpperBound | null {
-  const baseBoundMatch = baseBound.match(/(<=|<)\s*((\d+)(\.(\d+))?(\.(\d+))?)/);
-  if (!baseBoundMatch) return null;
-
-  const operator = baseBoundMatch[1];
-  const version = baseBoundMatch[2];
-  const inclusive = operator === "<=";
-
+function getUpperBound(constraint: string): BaseBound | null {
+  const match = constraint.match(/(<=|<)\s*((\d+)(\.(\d+))?(\.(\d+))?)/);
+  if (!match) return null;
   return {
-    inclusive,
-    version
+    inclusive: match[1] === "<=",
+    version: match[2]
+  };
+}
+
+function getLowerBound(constraint: string): BaseBound | null {
+  const match = constraint.match(/(>=|>)\s*((\d+)(\.(\d+))?(\.(\d+))?)/);
+  if (!match) return null;
+  return {
+    inclusive: match[1] === ">=",
+    version: match[2]
   };
 }
 
@@ -66,12 +76,26 @@ function compareVersions(a: string, b: string): number {
   return 0;
 }
 
-function satisfiesUpperBound(baseVersion: string, bound: BaseUpperBound): boolean {
+function satisfiesUpperBound(baseVersion: string, bound: BaseBound): boolean {
   const cmp = compareVersions(baseVersion, bound.version);
   return cmp < 0 || (cmp === 0 && bound.inclusive);
 }
 
-function parseBaseUpperBound(packageYamlPath: string): BaseUpperBound {
+function satisfiesLowerBound(baseVersion: string, bound: BaseBound): boolean {
+  const cmp = compareVersions(baseVersion, bound.version);
+  return cmp > 0 || (cmp === 0 && bound.inclusive);
+}
+
+function ghcMajorVersion(version: string): number {
+  return Number(version.split(".")[0]);
+}
+
+interface ParsedPackageYaml {
+  bounds: BaseBounds;
+  minTestedGhc: string | null;
+}
+
+function parsePackageYaml(packageYamlPath: string): ParsedPackageYaml {
   const fileContent = fs.readFileSync(packageYamlPath, "utf-8");
   const parsed = yaml.load(fileContent) as PackageYaml;
 
@@ -88,22 +112,46 @@ function parseBaseUpperBound(packageYamlPath: string): BaseUpperBound {
 
   if (!baseDep) throw new Error("No base dependency found in package.yaml");
 
-  const versionConstraint =
-    typeof baseDep === "string" ?
-    getBaseUpperBound(baseDep) :
-    getBaseUpperBound(baseDep.version);
+  const constraint = typeof baseDep === "string" ? baseDep : baseDep.version;
+  const upper = getUpperBound(constraint);
+  if (!upper) throw new Error("No upper bound for base found in package.yaml");
 
-  if (!versionConstraint) throw new Error("No upper bound for base found in package.yaml");
+  const bounds: BaseBounds = {
+    lower: getLowerBound(constraint),
+    upper
+  };
 
-  return versionConstraint;
+  const testedWith = parsed["tested-with"];
+  let minTestedGhc: string | null = null;
+  if (testedWith) {
+    const versions = [...testedWith.matchAll(/GHC\s*==\s*([\d.]+)/g)]
+      .map((m) => m[1]);
+    if (versions.length > 0) {
+      versions.sort(compareVersions);
+      minTestedGhc = versions[0];
+    }
+  }
+
+  return {
+    bounds,
+    minTestedGhc
+  };
 }
 
 async function main(): Promise < void > {
   try {
     const packageYamlPath =
       githubCore.getInput("package-yaml-path") || path.join(process.cwd(), "package.yaml");
+    const validateLowerBound = githubCore.getInput("validate-lower-bound") === "true";
 
-    const baseUpperBound = parseBaseUpperBound(packageYamlPath);
+    const {
+      bounds: {
+        lower: baseLowerBound,
+        upper: baseUpperBound
+      },
+      minTestedGhc
+    } =
+    parsePackageYaml(packageYamlPath);
 
     const ghcupListStr = await runCommand("ghcup list -t ghc -r");
     const lines = ghcupListStr.split("\n").filter(Boolean);
@@ -120,6 +168,22 @@ async function main(): Promise < void > {
       .filter((x): x is GhcEntry => x !== null);
 
     if (ghcupList.length === 0) throw new Error("Failed to get GHC versions from GHCup");
+
+    if (validateLowerBound && baseLowerBound && minTestedGhc) {
+      const minTestedMajor = ghcMajorVersion(minTestedGhc);
+      const breakingVersions = ghcupList.filter((entry) =>
+        satisfiesLowerBound(entry.base, baseLowerBound) &&
+        compareVersions(entry.version, minTestedGhc) < 0 &&
+        ghcMajorVersion(entry.version) < minTestedMajor
+      );
+      if (breakingVersions.length > 0) {
+        const oldest = breakingVersions[breakingVersions.length - 1].version;
+        const newest = breakingVersions[0].version;
+        throw new Error(
+          `base lower bound covers GHC ${oldest}..${newest} which have breaking changes relative to minimum tested version ${minTestedGhc}`
+        );
+      }
+    }
 
     const validVersions = ghcupList.filter((ghcEntry) =>
       satisfiesUpperBound(ghcEntry.base, baseUpperBound)

--- a/src/index.ts
+++ b/src/index.ts
@@ -203,7 +203,22 @@ async function main(): Promise < void > {
       `Latest GHC under base <${baseUpperBound.inclusive ? "=" : ""} ${baseUpperBound.version}: ${latestGhc}`
     );
 
+    githubCore.setOutput("max-ghc-version", latestGhc);
     githubCore.setOutput("ghc-version", latestGhc);
+
+    if (baseLowerBound) {
+      const lowerCandidates = ghcupList.filter((entry) =>
+        satisfiesLowerBound(entry.base, baseLowerBound)
+      );
+      if (lowerCandidates.length > 0) {
+        lowerCandidates.sort((a, b) => compareVersions(a.version, b.version));
+        const minGhc = lowerCandidates[0].version;
+        githubCore.info(
+          `Oldest GHC under base >${baseLowerBound.inclusive ? "=" : ""} ${baseLowerBound.version}: ${minGhc}`
+        );
+        githubCore.setOutput("min-ghc-version", minGhc);
+      }
+    }
   } catch (err: unknown) {
     githubCore.setFailed(err instanceof Error ? err.message : String(err));
   }


### PR DESCRIPTION
## Summary

- Parse `tested-with` from package.yaml to find the minimum tested GHC version
- Add `validate-lower-bound` input - fails if the base lower bound covers GHC major versions with breaking changes below the tested minimum
- Add `max-ghc-version` output (rename of `ghc-version`) and `min-ghc-version` output with the oldest GHC satisfying the lower bound
- Keep `ghc-version` as deprecated backwards-compatible output

## Test plan

- Updated integration tests to assert `max-ghc-version` and verify `min-ghc-version` is set
- Added `examples/package-validate-lower-bound.yaml` with `tested-with` and asserts `validate-lower-bound: true` passes and `min-ghc-version` is `9.0.1`
- Verified deprecated `ghc-version` output matches `max-ghc-version`