### PR TITLE
Support missing upper base bound

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -6,7 +6,7 @@ on:
   pull_request:
 
 jobs:
-  integration-test:
+  test:
     runs-on: ${{ matrix.os }}
     defaults:
       run:
@@ -107,3 +107,17 @@ jobs:
             exit 1
           fi
 
+      - name: Run action with no upper bound
+        uses: ./
+        with:
+          package-yaml-path: examples/package-no-upper-bound.yaml
+        id: ghc-version-no-upper
+      - name: Assert max-ghc-version is set when no upper bound
+        run: |-
+          v="${{ steps.ghc-version-no-upper.outputs.max-ghc-version }}"
+          if [[ ! "$v" =~ ^[0-9]+\.[0-9]+\.[0-9] ]]; then
+            echo "Expected max-ghc-version to be a valid version, got '$v'"
+            exit 1
+          fi
+
+      - run: npm test

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,9 +8,6 @@ on:
 jobs:
   test:
     runs-on: ${{ matrix.os }}
-    defaults:
-      run:
-        shell: bash
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
@@ -26,98 +23,5 @@ jobs:
         run: |
           npm run format
           git diff --exit-code
-      - run: npm run build
-      - name: Run action with inclusive upper bound
-        uses: ./
-        with:
-          package-yaml-path: examples/package-equal-or-less-than.yaml
-        id: ghc-version-inclusive
-      - name: Assert max-ghc-version output is a valid version string
-        run: |-
-          v="${{ steps.ghc-version-inclusive.outputs.max-ghc-version }}"
-          if [[ ! "$v" =~ ^[0-9]+\.[0-9]+\.[0-9] ]]; then
-            echo "Expected max-ghc-version to be a valid version, got '$v'"
-            exit 1
-          fi
-      - name: Assert ghc-versions output is a non-empty JSON array
-        run: |-
-          v="${{ steps.ghc-version-inclusive.outputs.ghc-versions }}"
-          if [[ "$v" != \[* ]] || [ "$v" = "[]" ]; then
-            echo "Expected ghc-versions to be a non-empty JSON array, got '$v'"
-            exit 1
-          fi
-
-      - name: Assert deprecated ghc-version output matches max-ghc-version
-        run: |-
-          if [ "${{ steps.ghc-version-inclusive.outputs.ghc-version }}" != "${{ steps.ghc-version-inclusive.outputs.max-ghc-version }}" ]; then
-            echo "Expected ghc-version '${{ steps.ghc-version-inclusive.outputs.ghc-version }}' to match max-ghc-version '${{ steps.ghc-version-inclusive.outputs.max-ghc-version }}'"
-            exit 1
-          fi
-
-      - name: Assert min-ghc-version output is set
-        run: |-
-          if [ -z "${{ steps.ghc-version-inclusive.outputs.min-ghc-version }}" ]; then
-            echo "Expected min-ghc-version to be set, but it was empty"
-            exit 1
-          fi
-
-      - name: Run action with exclusive upper bound
-        uses: ./
-        with:
-          package-yaml-path: examples/package-less-than.yaml
-        id: ghc-version-exclusive
-      - name: Assert max-ghc-version output is a valid version string
-        run: |-
-          v="${{ steps.ghc-version-exclusive.outputs.max-ghc-version }}"
-          if [[ ! "$v" =~ ^[0-9]+\.[0-9]+\.[0-9] ]]; then
-            echo "Expected max-ghc-version to be a valid version, got '$v'"
-            exit 1
-          fi
-
-      - name: Run action with validate-lower-bound
-        uses: ./
-        with:
-          package-yaml-path: examples/package-validate-lower-bound.yaml
-          validate-lower-bound: 'true'
-        id: ghc-version-validated
-      - name: Assert validate-lower-bound passes and max-ghc-version is set
-        run: |-
-          if [ -z "${{ steps.ghc-version-validated.outputs.max-ghc-version }}" ]; then
-            echo "Expected max-ghc-version to be set, but it was empty"
-            exit 1
-          fi
-
-      - name: Assert min-ghc-version is a valid version string
-        run: |-
-          v="${{ steps.ghc-version-validated.outputs.min-ghc-version }}"
-          if [[ ! "$v" =~ ^[0-9]+\.[0-9]+\.[0-9] ]]; then
-            echo "Expected min-ghc-version to be a valid version, got '$v'"
-            exit 1
-          fi
-      - name: Run action with validate-lower-bound warn
-        uses: ./
-        with:
-          package-yaml-path: examples/package-validate-lower-bound-warn.yaml
-          validate-lower-bound: 'warn'
-        id: ghc-version-warn
-      - name: Assert warn mode sets max-ghc-version despite wide lower bound
-        run: |-
-          if [ -z "${{ steps.ghc-version-warn.outputs.max-ghc-version }}" ]; then
-            echo "Expected max-ghc-version to be set in warn mode, but it was empty"
-            exit 1
-          fi
-
-      - name: Run action with no upper bound
-        uses: ./
-        with:
-          package-yaml-path: examples/package-no-upper-bound.yaml
-        id: ghc-version-no-upper
-      - name: Assert max-ghc-version is set when no upper bound
-        run: |-
-          v="${{ steps.ghc-version-no-upper.outputs.max-ghc-version }}"
-          if [[ ! "$v" =~ ^[0-9]+\.[0-9]+\.[0-9] ]]; then
-            echo "Expected max-ghc-version to be a valid version, got '$v'"
-            exit 1
-          fi
-
+        shell: bash
       - run: npm test

--- a/examples/package-no-upper-bound.yaml
+++ b/examples/package-no-upper-bound.yaml
@@ -1,0 +1,13 @@
+name: my-haskell-package
+version: 0.1.0.0
+
+dependencies:
+  - name: base
+    version: '>= 4.10'
+  - containers
+  - text
+
+library:
+  exposed-modules: MyLib
+  source-dirs: src
+  ghc-options: -Wall

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "main": "index.js",
   "scripts": {
     "build": "esbuild src/index.ts --bundle --platform=node --outfile=dist/index.js",
-    "format": "js-beautify -r ./**/*.ts ./package.json"
+    "format": "js-beautify -r ./**/*.ts ./package.json",
+    "test": "npm run build --silent && node test.mjs"
   },
   "dependencies": {
     "@actions/core": "^3.0.1",

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,7 @@ interface BaseBound {
 
 interface BaseBounds {
   lower: BaseBound | null;
-  upper: BaseBound;
+  upper: BaseBound | null;
 }
 
 interface PackageYaml {
@@ -143,12 +143,9 @@ function parsePackageYaml(packageYamlPath: string): ParsedPackageYaml {
   if (!baseDep) throw new Error("No base dependency found in package.yaml");
 
   const constraint = typeof baseDep === "string" ? baseDep : baseDep.version;
-  const upper = getUpperBound(constraint);
-  if (!upper) throw new Error("No upper bound for base found in package.yaml");
-
   const bounds: BaseBounds = {
     lower: getLowerBound(constraint),
-    upper
+    upper: getUpperBound(constraint)
   };
 
   const testedWithRaw = parsed["tested-with"];
@@ -230,13 +227,15 @@ async function main(): Promise < void > {
       }
     }
 
-    const validVersions = ghcupList.filter((ghcEntry) =>
-      satisfiesUpperBound(ghcEntry.base, baseUpperBound)
-    );
+    const validVersions = baseUpperBound
+      ? ghcupList.filter((ghcEntry) => satisfiesUpperBound(ghcEntry.base, baseUpperBound))
+      : ghcupList;
 
     if (validVersions.length === 0) {
       throw new Error(
-        `No GHC version found with base ${boundOp(baseUpperBound, "<")} ${baseUpperBound.version}`
+        baseUpperBound
+          ? `No GHC version found with base ${boundOp(baseUpperBound, "<")} ${baseUpperBound.version}`
+          : "No GHC versions found"
       );
     }
 
@@ -248,7 +247,9 @@ async function main(): Promise < void > {
     const latestGhc = validVersions[0].version;
 
     githubCore.info(
-      `Latest GHC under base ${boundOp(baseUpperBound, "<")} ${baseUpperBound.version}: ${latestGhc}`
+      baseUpperBound
+        ? `Latest GHC under base ${boundOp(baseUpperBound, "<")} ${baseUpperBound.version}: ${latestGhc}`
+        : `Latest GHC (no upper base bound): ${latestGhc}`
     );
 
     githubCore.setOutput("max-ghc-version", latestGhc);

--- a/src/index.ts
+++ b/src/index.ts
@@ -227,15 +227,15 @@ async function main(): Promise < void > {
       }
     }
 
-    const validVersions = baseUpperBound
-      ? ghcupList.filter((ghcEntry) => satisfiesUpperBound(ghcEntry.base, baseUpperBound))
-      : ghcupList;
+    const validVersions = baseUpperBound ?
+      ghcupList.filter((ghcEntry) => satisfiesUpperBound(ghcEntry.base, baseUpperBound)) :
+      ghcupList;
 
     if (validVersions.length === 0) {
       throw new Error(
-        baseUpperBound
-          ? `No GHC version found with base ${boundOp(baseUpperBound, "<")} ${baseUpperBound.version}`
-          : "No GHC versions found"
+        baseUpperBound ?
+        `No GHC version found with base ${boundOp(baseUpperBound, "<")} ${baseUpperBound.version}` :
+        "No GHC versions found"
       );
     }
 
@@ -247,9 +247,9 @@ async function main(): Promise < void > {
     const latestGhc = validVersions[0].version;
 
     githubCore.info(
-      baseUpperBound
-        ? `Latest GHC under base ${boundOp(baseUpperBound, "<")} ${baseUpperBound.version}: ${latestGhc}`
-        : `Latest GHC (no upper base bound): ${latestGhc}`
+      baseUpperBound ?
+      `Latest GHC under base ${boundOp(baseUpperBound, "<")} ${baseUpperBound.version}: ${latestGhc}` :
+      `Latest GHC (no upper base bound): ${latestGhc}`
     );
 
     githubCore.setOutput("max-ghc-version", latestGhc);

--- a/test.mjs
+++ b/test.mjs
@@ -1,0 +1,76 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+function parseGitHubOutput(content) {
+  const outputs = {};
+  const lines = content.split("\n");
+  let i = 0;
+  while (i < lines.length) {
+    const heredocMatch = lines[i].match(/^([^<]+)<<(.+)$/);
+    if (heredocMatch) {
+      const [, key, delimiter] = heredocMatch;
+      const valueLines = [];
+      i++;
+      while (i < lines.length && lines[i] !== delimiter) {
+        valueLines.push(lines[i]);
+        i++;
+      }
+      outputs[key] = valueLines.join("\n");
+    }
+    i++;
+  }
+  return outputs;
+}
+
+function runAction(yamlPath, validateLowerBound = false) {
+  const dir = mkdtempSync(join(tmpdir(), "gsg-test-"));
+  const outputFile = join(dir, "output");
+  writeFileSync(outputFile, "");
+
+  const result = spawnSync("node", ["dist/index.js"], {
+    env: {
+      ...process.env,
+      "INPUT_PACKAGE-YAML-PATH": yamlPath,
+      "INPUT_VALIDATE-LOWER-BOUND": String(validateLowerBound),
+      GITHUB_OUTPUT: outputFile,
+    },
+    encoding: "utf-8",
+  });
+
+  const outputs = parseGitHubOutput(readFileSync(outputFile, "utf-8"));
+
+  rmSync(dir, { recursive: true });
+
+  if (result.status !== 0) {
+    throw new Error(`Action failed:\n${result.stdout}${result.stderr}`);
+  }
+
+  return outputs;
+}
+
+test("inclusive upper bound", () => {
+  const out = runAction("examples/package-equal-or-less-than.yaml");
+  assert.equal(out["max-ghc-version"], "9.0.1");
+  assert.equal(out["ghc-version"], out["max-ghc-version"]);
+  assert.ok(out["min-ghc-version"]);
+});
+
+test("exclusive upper bound", () => {
+  const out = runAction("examples/package-less-than.yaml");
+  assert.equal(out["max-ghc-version"], "8.10.7");
+});
+
+test("validate-lower-bound", () => {
+  const out = runAction("examples/package-validate-lower-bound.yaml", true);
+  assert.ok(out["max-ghc-version"]);
+  assert.equal(out["min-ghc-version"], "9.0.1");
+});
+
+test("no upper bound uses latest ghc", () => {
+  const out = runAction("examples/package-no-upper-bound.yaml");
+  assert.ok(out["max-ghc-version"]);
+});

--- a/test.mjs
+++ b/test.mjs
@@ -7,7 +7,7 @@ import { join } from "node:path";
 
 function parseGitHubOutput(content) {
   const outputs = {};
-  const lines = content.split("\n");
+  const lines = content.split(/\r?\n/);
   let i = 0;
   while (i < lines.length) {
     const heredocMatch = lines[i].match(/^([^<]+)<<(.+)$/);
@@ -15,8 +15,8 @@ function parseGitHubOutput(content) {
       const [, key, delimiter] = heredocMatch;
       const valueLines = [];
       i++;
-      while (i < lines.length && lines[i] !== delimiter) {
-        valueLines.push(lines[i]);
+      while (i < lines.length && lines[i].trimEnd() !== delimiter) {
+        valueLines.push(lines[i].trimEnd());
         i++;
       }
       outputs[key] = valueLines.join("\n");


### PR DESCRIPTION
When `package.yaml` has no upper bound on `base` (e.g. `>= 4.10` with no `<` or `<=`), the action now uses the latest available GHC version instead of failing.

Also adds a local test suite (`npm test`) backed by `test.mjs` using Node's built-in test runner, and wires it into CI alongside the existing integration tests.